### PR TITLE
fix: allure report command line missing dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 allure-results
+allure-report

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
+<p align="center">
+    <a href="https://webdriver.io/">
+        <img alt="WebdriverIO" src="https://webdriver.io/assets/images/robot-3677788dd63849c56aa5cb3f332b12d5.svg" width="146">
+    </a>
+</p>
+
 # UI Test Automation - WebDriverIO
-## Starter project creado en vivo en [stream de Twitch](https://www.twitch.tv/charlyautomatiza)
+## Starter project creado en vivo en [stream de Twitch](https://www.twitch.tv/charlyautomatiza) basado en [WebDriverIO](https://webdriver.io/), [Cucumber](https://cucumber.io/), [TypeScript](https://www.typescriptlang.org/) y [Allure Report](https://docs.qameta.io/allure-report/).
 
 ### Requerimientos
 
@@ -24,3 +30,11 @@
 **Para ejecutar el asistente de configuración (opcional para usar otros browsers o servicios):**
 
     npm init wdio .
+
+**Para crear el reporte unificado de Allure Report con los resultados de los test**
+
+    npm run clean-report
+
+**Para abrir el reporte unificado de los resultados de los test**
+
+    npm run open-report

--- a/package-lock.json
+++ b/package-lock.json
@@ -884,6 +884,12 @@
         }
       }
     },
+    "allure-commandline": {
+      "version": "2.13.8",
+      "resolved": "https://registry.npmjs.org/allure-commandline/-/allure-commandline-2.13.8.tgz",
+      "integrity": "sha512-LxP4a/nigaH1al6TZU+JVio8j205XXYhL2ATG22tU2F7xTlEkO4SbAUY8Bq366J6C136EdZAoFUeEsGrJsI7BA==",
+      "dev": true
+    },
     "allure-js-commons": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-1.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "main": "index.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
-        "clean": "rimraf .tsbuid && rimraf allure-results && rimraf junit-results",
+        "clean": "rimraf .tsbuid && rimraf allure-results && rimraf allure-report && rimraf junit-results",
+        "clean-report": "allure generate --clean ./allure-results",
+        "open-report": "allure open",
         "wdio": "npm run clean && wdio run wdio.conf.ts"
     },
     "repository": {
@@ -31,6 +33,7 @@
         "@wdio/junit-reporter": "^7.16.11",
         "@wdio/local-runner": "^7.16.11",
         "@wdio/spec-reporter": "^7.16.11",
+        "allure-commandline": "^2.13.8",
         "chromedriver": "^96.0.0",
         "ts-node": "^10.4.0",
         "typescript": "^4.5.3",


### PR DESCRIPTION
- Missing dependency: "allure-commandline" to be able to generate our unified Allure Report
- New commands "clean-report" and "open-report" to create and open our Allure Report
- You can see readme file for more details.